### PR TITLE
Fix 500 on new message alert and MYSQL strict mode (ONLY_FULL_GROUP_BY)

### DIFF
--- a/modules/mail/includes/input.php
+++ b/modules/mail/includes/input.php
@@ -34,7 +34,7 @@ $total = $db->query(
 
 if ($total) {
     $req = $db->query(
-        "SELECT `users`.*, MAX(`cms_mail`.`time`) AS `time`
+        "SELECT `users`.`id`, `users`.`name`, `users`.`rights`, `users`.`lastdate`, `users`.`ip`, MAX(`cms_mail`.`time`) AS `time`
 		FROM `cms_mail`
 		LEFT JOIN `users` ON `cms_mail`.`user_id`=`users`.`id`
 		LEFT JOIN `cms_contact` ON `cms_mail`.`user_id`=`cms_contact`.`from_id` AND `cms_contact`.`user_id`='" . $user->id . "'
@@ -42,7 +42,7 @@ if ($total) {
 		AND `cms_mail`.`delete`!='" . $user->id . "'
 		AND `cms_mail`.`sys`='0'
 		AND `cms_contact`.`ban`!='1'
-		GROUP BY `cms_mail`.`user_id`
+		GROUP BY `users`.`id`, `users`.`name`, `users`.`rights`, `users`.`lastdate`, `users`.`ip`
 		ORDER BY MAX(`cms_mail`.`time`) DESC
 		LIMIT " . $start . ',' . $user->config->kmess
     );


### PR DESCRIPTION
Fix Error 500 in case when User have new mails and use MYSQL without disabling ONLY_FULL_GROUP_BY

## Description
Use only needed fields from database and add them to GROUP BY

## How Has This Been Tested?
Tested on stag server (PHP 7.4, MariaDB 10.11.4, using Fastpanel default database settings)

## Types of changes
- [✔] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [✔ ] My code follows the code style of this project.
- [✔ ] I have read the **CONTRIBUTING** document.
- [ ✔] I have run `composer check` locally, and there were no failures or errors.

![изображение_2024-08-04_101545813](https://github.com/user-attachments/assets/560835be-f22c-466b-a4b0-c0c25b49584d)
 